### PR TITLE
Fix mousedown not coloring the initial module

### DIFF
--- a/scripts/sketch-grid.js
+++ b/scripts/sketch-grid.js
@@ -20,8 +20,9 @@ function colorGridModule(hasNewColor = false) {
     if (hasNewColor) {
         removeEventListener('mouseover', setColor);
     }
-    gridContainer.addEventListener('mousedown', (e) => e.preventDefault());
+    gridContainer.addEventListener('mousedown', setColor);
     gridContainer.addEventListener('mouseover', setColor);
+    gridContainer.addEventListener('dragstart', (e) => e.preventDefault());
 }
 
 // Fill gridContainer with total amount of modules as divs


### PR DESCRIPTION
Fixes #1
Preventing default behavior of dragstart event stops the cursor from changing into the not-allowed state.